### PR TITLE
Update node to patch a CVE.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,3 +41,6 @@ services:
         build: ./proxy
         ports:
             - '8080:80'
+        depends_on:
+            - ui
+            - api

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.1-alpine
+FROM node:14.15.1-alpine3.12
 
 WORKDIR /usr/local/src/skiff/app/ui/
 


### PR DESCRIPTION
NodeJS distributed a patch for a high severity CVE, see:
https://twitter.com/nodejs/status/1328723765157617672?s=21

This is several major version updates combined into one,
which is admittedly risky, but I was able to get a local
environment stood up and click through everything, so
I think it's safe to do (and is a nice leap forward
that probably takes care of quite a few CVEs we didn't
realize we had).

Here's the relevant ticket:
https://github.com/allenai/reviz/issues/155