### PR TITLE
Update ini.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "typescript": "^3.5.3"
   },
   "resolutions": {
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "ini": "^1.3.8"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3693,10 +3693,10 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+ini@^1.3.8, ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 invariant@^2.2.2:
   version "2.2.4"


### PR DESCRIPTION
This uses the `resolutions` feature to force `ini` to a version
without the associated CVE. The update should be safe, since it's
a only a patch.

I tried to use the `--ignore-optional` flag `yarn` provides, but
it didn't work (`ini` is required by `rc` which is required by `sharp`
which is an optional dependency of `next`). It appears this is a known
issue: https://github.com/yarnpkg/yarn/issues/5366

Resolves:
https://github.com/allenai/supp.ai/security/dependabot/ui/yarn.lock/ini/open

In relation to:
https://github.com/allenai/reviz/issues/165