### PR TITLE
Allow overriding origin

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
             - 'PYTHONUNBUFFERED=1'
             - 'LOG_LEVEL=DEBUG'
             - 'SUPP_AI_ALGOLIA_API_KEY=${SUPP_AI_ALGOLIA_API_KEY}'
-            - 'SUPP_AI_CANONICAL_ORIGIN=http://localhost:8080'
+            - SUPP_AI_CANONICAL_ORIGIN=${SUPP_AI_CANONICAL_ORIGIN:-"http://localhost:8080"}
     ui:
         build: ./ui
         # We can't mount the entire UI directory, since the `node_modules`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
         command:
             - 'dev'
         environment:
-            - 'SUPP_AI_CANONICAL_ORIGIN=http://localhost:8080'
+            - SUPP_AI_CANONICAL_ORIGIN=${SUPP_AI_CANONICAL_ORIGIN:-"http://localhost:8080"}
     proxy:
         build: ./proxy
         ports:


### PR DESCRIPTION
This makes it possible to override the canonical origin using an environment variable, i.e.:

```
SUPP_AI_CANONICAL_ORIGIN=supp.ai docker compose up --build
```